### PR TITLE
Add kitchen coverage to all current recipes.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,6 +10,12 @@ platforms:
   - name: centos-7.0
 
 suites:
-  - name: default
+  - name: cron
     run_list:
-      - recipe[magento-ng::default]
+      - recipe[magento-ng::cron]
+  - name: etc-local
+    run_list:
+      - recipe[magento-ng::etc-local]
+  - name: stack
+    run_list:
+      - recipe[magento-ng::stack]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,6 +6,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  require_chef_omnibus: 12.3
 
 platforms:
   - name: centos-5.11
@@ -16,9 +17,30 @@ suites:
   - name: cron
     run_list:
       - recipe[magento-ng::cron]
+    attributes:
+      nginx:
+        sites:
+          site1:
+            server_name: "test.dev"
+            docroot: "/docroot"
+            type: "magento"
   - name: etc-local
     run_list:
       - recipe[magento-ng::etc-local]
+    attributes:
+      nginx:
+        sites:
+          site1:
+            server_name: "test.dev"
+            docroot: "/docroot"
+            type: "magento"
   - name: stack
     run_list:
       - recipe[magento-ng::stack]
+    attributes:
+      nginx:
+        sites:
+          site1:
+            server_name: "test.dev"
+            docroot: "/docroot"
+            type: "magento"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,8 +5,8 @@ driver:
     - ./test/.Vagrantfile.disable-berkshelf.rb
 
 provisioner:
-  name: chef_zero
-  require_chef_omnibus: 12.3
+  name: chef_solo
+  chef_omnibus_install_options: -d /tmp/vagrant-cache/vagrant_omnibus
 
 platforms:
   - name: centos-5.11
@@ -34,6 +34,9 @@ suites:
             server_name: "test.dev"
             docroot: "/docroot"
             type: "magento"
+            magento:
+              app:
+                crypt_key: "foo"
   - name: stack
     run_list:
       - recipe[magento-ng::stack]
@@ -44,3 +47,6 @@ suites:
             server_name: "test.dev"
             docroot: "/docroot"
             type: "magento"
+            magento:
+              app:
+                crypt_key: "foo"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,5 +1,8 @@
 driver:
   name: vagrant
+  vagrantfiles:
+    - ./test/.Vagrantfile.cachier.rb
+    - ./test/.Vagrantfile.disable-berkshelf.rb
 
 provisioner:
   name: chef_zero

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
 source "https://supermarket.getchef.com"
 
 metadata
+
+cookbook 'config-driven-helper', git: 'https://github.com/inviqa/chef-config-driven-helper.git', ref: '1.4.1'

--- a/test/.Vagrantfile.cachier.rb
+++ b/test/.Vagrantfile.cachier.rb
@@ -1,0 +1,41 @@
+Vagrant.configure('2') do |config|
+  # The following configuration supports shared folders with host
+  # aware configuration of NFS for performance benefits on unix based hosts
+  require 'ffi'
+  use_nfs = !FFI::Platform::IS_WINDOWS && ::File.exist?('/etc/sudoers.d/vagrant_nfs')
+  has_cachier = Vagrant.has_plugin?('vagrant-cachier')
+
+  config.vm.network 'private_network', type: 'dhcp'
+
+  # Enable Vagrant Cachier, for speedy destroy/creates
+  if has_cachier
+    # Configure cached packages to be shared between instances of the same base box.
+    # More info on http://fgrehm.viewdocs.io/vagrant-cachier/usage
+    config.cache.scope = :box
+
+    if use_nfs
+      # OPTIONAL: If you are using VirtualBox, you might want to use that to enable
+      # NFS for shared folders. This is also very useful for vagrant-libvirt if you
+      # want bi-directional sync
+      config.cache.synced_folder_opts = {
+        type: :nfs,
+        # The nolock option can be useful for an NFSv3 client that wants to avoid the
+        # NLM sideband protocol. Without this option, apt-get might hang if it tries
+        # to lock files needed for /var/cache/* operations. All of this can be avoided
+        # by using NFSv4 everywhere. Please note that the tcp option is not the default.
+        mount_options: ['rw', 'vers=3', 'tcp', 'nolock']
+      }
+    end
+
+    config.cache.enable :chef
+    config.cache.enable :yum
+    config.cache.enable :gem
+  end
+
+  config.vm.provision :chef_solo do |chef|
+    chef.file_cache_path = chef.provisioning_path unless has_cachier
+
+    # Mount chef folders via NFS for speed
+    chef.synced_folder_type = 'nfs' if use_nfs
+  end
+end

--- a/test/.Vagrantfile.disable-berkshelf.rb
+++ b/test/.Vagrantfile.disable-berkshelf.rb
@@ -1,0 +1,3 @@
+Vagrant.configure('2') do |config|
+  config.berkshelf.enabled = false if Vagrant.has_plugin?('vagrant-berkshelf')
+end


### PR DESCRIPTION
Only performs a converge but already we have a few outcomes.

etc-local is failing due to:
```
* Parent directory /docroot/app/etc does not exist.
           ================================================================================
           Error executing action `create` on resource 'template[/docroot/app/etc/local.xml]'
           ================================================================================

           Chef::Exceptions::EnclosingDirectoryDoesNotExist
           ------------------------------------------------
           Parent directory /docroot/app/etc does not exist.

           Resource Declaration:
           ---------------------
           # In /tmp/kitchen/cookbooks/magento-ng/recipes/etc-local.rb

            33:     template "#{config_path}/app/etc/local.xml" do
            34:       source "magento-local.xml.erb"
            35:       mode 0644
            36:       variables({
            37:         :magento => magento
            38:       })
            39:     end
            40:   end```

Should we be creating the `#{config_path}/app/etc/` folder if it doesn't exist?