### PR TITLE
Feature/use custom cron sh for crond

### DIFF
--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -15,10 +15,21 @@
       include_recipe 'cron::default'
 
       cron_d "magento-#{name}" do
-        if !site['clustered']
-          command "sh #{site['docroot']}/cron.sh"
+
+        if site['aoe_scheduler']
+          if !site['clustered']
+            command "sh #{site['docroot']}/schedule_cron.sh --mode always"
+            command "sh #{site['docroot']}/schedule_cron.sh --mode default"
+          else
+            command "bash -c '[ -f #{site['clustered']['primary_indicator']} ] && sh #{site['docroot']}/schedule_cron.sh '"
+          end
+
         else
-          command "bash -c '[ -f #{site['clustered']['primary_indicator']} ] && sh #{site['docroot']}/cron.sh'"
+            if !site['clustered']
+              command "sh #{site['docroot']}/cron.sh"
+            else
+              command "bash -c '[ -f #{site['clustered']['primary_indicator']} ] && sh #{site['docroot']}/cron.sh'"
+            end
         end
 
         if (!site['cron'].nil?) && site['cron']['user']

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -20,8 +20,18 @@
           if !site['clustered']
             command "sh #{site['docroot']}/schedule_cron.sh --mode always"
             command "sh #{site['docroot']}/schedule_cron.sh --mode default"
+
+            if site['watchdog']
+              command "cd #{site['docroot']}/shell && /usr/bin/php scheduler.php --action watchdog"
+            end
+
           else
-            command "bash -c '[ -f #{site['clustered']['primary_indicator']} ] && sh #{site['docroot']}/schedule_cron.sh '"
+            command "bash -c '[ -f #{site['clustered']['primary_indicator']} ] && sh #{site['docroot']}/schedule_cron.sh --mode always'"
+            command "bash -c '[ -f #{site['clustered']['primary_indicator']} ] && sh #{site['docroot']}/schedule_cron.sh --mode default'"
+
+            if site['watchdog']
+              command "bash -c '[ -f #{site['clustered']['primary_indicator']} ] && cd #{site['docroot']}/shell && /usr/bin/php scheduler.php --action watchdog'"
+            end
           end
 
         else

--- a/spec/recipes/cron_spec.rb
+++ b/spec/recipes/cron_spec.rb
@@ -31,6 +31,25 @@ describe 'magento-ng::cron' do
     end
   end
 
+   context 'with schedule cron ' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['nginx']['sites'] = {}
+        node.set['apache']['sites']['project']['type'] = 'magento'
+        node.set['apache']['sites']['project']['docroot'] = '/var/www/project/current/public'
+        node.set['apache']['sites']['project']['aoe_scheduler'] = true
+      end.converge(described_recipe)
+    end
+
+   it "creates project cron.d file using schdule cron sh" do
+      expect(chef_run).to create_cron_d('magento-project').with(
+        command: 'sh /var/www/project/current/public/schedule_cron.sh --mode always',
+        command: 'sh /var/www/project/current/public/schedule_cron.sh --mode default',
+        user: 'www-data'
+      )
+    end
+  end
+
   context 'with default attributes and one nginx project site' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|

--- a/spec/recipes/cron_spec.rb
+++ b/spec/recipes/cron_spec.rb
@@ -31,17 +31,39 @@ describe 'magento-ng::cron' do
     end
   end
 
-   context 'with schedule cron ' do
+   context 'with aow schedule and watchdog' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
         node.set['nginx']['sites'] = {}
         node.set['apache']['sites']['project']['type'] = 'magento'
         node.set['apache']['sites']['project']['docroot'] = '/var/www/project/current/public'
         node.set['apache']['sites']['project']['aoe_scheduler'] = true
+        node.set['apache']['sites']['project']['watchdog'] = true
       end.converge(described_recipe)
     end
 
-   it "creates project cron.d file using schdule cron sh" do
+   it "creates project cron.d file using aoe schdule and watchdog" do
+      expect(chef_run).to create_cron_d('magento-project').with(
+        command: 'sh /var/www/project/current/public/schedule_cron.sh --mode always',
+        command: 'sh /var/www/project/current/public/schedule_cron.sh --mode default',
+        command: 'cd /var/www/project/current/public/shell && /usr/bin/php scheduler.php --action watchdog',
+        user: 'www-data'
+      )
+    end
+  end
+
+   context 'with aoe schedule but no watchdog ' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['nginx']['sites'] = {}
+        node.set['apache']['sites']['project']['type'] = 'magento'
+        node.set['apache']['sites']['project']['docroot'] = '/var/www/project/current/public'
+        node.set['apache']['sites']['project']['aoe_scheduler'] = true
+        node.set['apache']['sites']['project']['watchdog'] = false
+      end.converge(described_recipe)
+    end
+
+   it "creates project cron.d file using aoe schduler and no watchdog" do
       expect(chef_run).to create_cron_d('magento-project').with(
         command: 'sh /var/www/project/current/public/schedule_cron.sh --mode always',
         command: 'sh /var/www/project/current/public/schedule_cron.sh --mode default',


### PR DESCRIPTION
- [x] Add aoe scheduler flag to use scheduler_cron.sh file
- [x] Add watchdog flag to add additional command for watchdog

`.../scheduler_cron.sh --mode always`
`.../scheduler_cron.sh --mode default`
`...cd /vagrant/public/shell && /usr/bin/php scheduler.php --action watchdog`