### PR TITLE
Add support for AOE Scheduler cron and watchdog

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,6 +24,18 @@ suites:
             server_name: "test.dev"
             docroot: "/docroot"
             type: "magento"
+  - name: cron-aoe
+    run_list:
+      - recipe[magento-ng::cron]
+    attributes:
+      nginx:
+        sites:
+          site1:
+            aoe_scheduler: true
+            watchdog: true
+            server_name: "test.dev"
+            docroot: "/docroot"
+            type: "magento"
   - name: etc-local
     run_list:
       - recipe[magento-ng::etc-local]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.0 (21 September 2015)
+
+FEATURES
+
+  * Add support for AOE Scheduler cron and watchdog
+
 ## 0.2.1 (9 July 2015)
 
 BUG FIXES

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,6 +44,13 @@ default['magento']['global']['extra_params'] = {
   'skip_process_modules_updates_dev_mode' => 1,
 }
 
+default['magento']['cron_type'] = 'standard'
+default['magento']['cron']['minute'] = '*'
+default['magento']['aoe_scheduler']['always']['minute'] = '*'
+default['magento']['aoe_scheduler']['default']['minute'] = '*'
+default['magento']['aoe_scheduler']['watchdog']['minute'] = '*/10'
+default['magento']['aoe_scheduler']['watchdog']['enabled'] = true
+
 %w( apache nginx ).each do |type|
   default[type]['shared_config']['magento'] = {
     'clustered' => false,

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'athompson@inviqa.com'
 license          'All rights reserved'
 description      'Installs/Configures magento-ng'
 long_description 'Installs/Configures magento-ng'
-version          '0.2.1'
+version          '0.3.0'
 
 depends 'config-driven-helper', '~> 1.4'
 depends 'cron', '~> 1.4'

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -15,10 +15,21 @@
       include_recipe 'cron::default'
 
       cron_d "magento-#{name}" do
-        if !site['clustered']
-          command "sh #{site['docroot']}/cron.sh"
+
+        if site['aoe_scheduler']
+          if !site['clustered']
+            command "sh #{site['docroot']}/schedule_cron.sh --mode always"
+            command "sh #{site['docroot']}/schedule_cron.sh --mode default"
+          else
+            command "bash -c '[ -f #{site['clustered']['primary_indicator']} ] && sh #{site['docroot']}/schedule_cron.sh '"
+          end
+
         else
-          command "bash -c '[ -f #{site['clustered']['primary_indicator']} ] && sh #{site['docroot']}/cron.sh'"
+            if !site['clustered']
+              command "sh #{site['docroot']}/cron.sh"
+            else
+              command "bash -c '[ -f #{site['clustered']['primary_indicator']} ] && sh #{site['docroot']}/cron.sh'"
+            end
         end
 
         if (!site['cron'].nil?) && site['cron']['user']

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -20,8 +20,18 @@
           if !site['clustered']
             command "sh #{site['docroot']}/schedule_cron.sh --mode always"
             command "sh #{site['docroot']}/schedule_cron.sh --mode default"
+
+            if site['watchdog']
+              command "cd #{site['docroot']}/shell && /usr/bin/php scheduler.php --action watchdog"
+            end
+
           else
-            command "bash -c '[ -f #{site['clustered']['primary_indicator']} ] && sh #{site['docroot']}/schedule_cron.sh '"
+            command "bash -c '[ -f #{site['clustered']['primary_indicator']} ] && sh #{site['docroot']}/schedule_cron.sh --mode always'"
+            command "bash -c '[ -f #{site['clustered']['primary_indicator']} ] && sh #{site['docroot']}/schedule_cron.sh --mode default'"
+
+            if site['watchdog']
+              command "bash -c '[ -f #{site['clustered']['primary_indicator']} ] && cd #{site['docroot']}/shell && /usr/bin/php scheduler.php --action watchdog'"
+            end
           end
 
         else

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -19,28 +19,49 @@
         primary_indicator_check = "bash -c '[ -f #{site['clustered']['primary_indicator']} ] && "
       end
 
-      cron_d "magento-#{name}" do
+      magento = ConfigDrivenHelper::Util::immutablemash_to_hash(node['magento'])
 
-        if site['aoe_scheduler']
-          command "#{primary_indicator_check}sh #{site['docroot']}/schedule_cron.sh --mode always"
-          command "#{primary_indicator_check}sh #{site['docroot']}/schedule_cron.sh --mode default"
-
-          if site['watchdog']
-            command "#{primary_indicator_check}cd #{site['docroot']}/shell && /usr/bin/php scheduler.php --action watchdog"
-          end
-        else
-          command "#{primary_indicator_check}sh #{site['docroot']}/cron.sh"
-        end
-
-        if (!site['cron'].nil?) && site['cron']['user']
-          user site['cron']['user']
+      if site['magento']
+        magento = ::Chef::Mixin::DeepMerge.hash_only_merge(
+          magento,
+          ConfigDrivenHelper::Util::immutablemash_to_hash(site['magento']))
+      end
+      
+      cron_user = if (!site['cron'].nil?) && site['cron']['user']
+          site['cron']['user']
         else
           case type
           when 'apache'
-            user node['apache']['user']
+            node['apache']['user']
           when 'nginx'
-            user node['php-fpm']['pools']['www']['user'].nil? ? node['php-fpm']['user'] : node['php-fpm']['pools']['www']['user']
+            node['php-fpm']['pools']['www']['user'].nil? ? node['php-fpm']['user'] : node['php-fpm']['pools']['www']['user']
           end
+        end
+
+      if magento['cron_type'] == 'aoe_scheduler'
+        cron_d "magento-#{name}-aoe-always" do
+          command "#{primary_indicator_check}sh #{site['docroot']}/scheduler_cron.sh --mode always"
+          minute magento['aoe_scheduler']['always']['minute']
+          user cron_user
+        end
+
+        cron_d "magento-#{name}-aoe-default" do
+          command "#{primary_indicator_check}sh #{site['docroot']}/scheduler_cron.sh --mode default"
+          minute magento['aoe_scheduler']['default']['minute']
+          user cron_user
+        end
+        if magento['aoe_scheduler']['watchdog']['enabled']
+          cron_d "magento-#{name}-aoe-watchdog" do
+            command "#{primary_indicator_check}cd #{site['docroot']}/shell && /usr/bin/php scheduler.php --action watchdog"
+            minute magento['aoe_scheduler']['watchdog']['minute']
+            user cron_user
+          end
+        end
+      else
+        cron_d "magento-#{name}" do
+          command "#{primary_indicator_check}sh #{site['docroot']}/cron.sh"
+          minute magento['cron']['minute']
+          user cron_user
         end
       end
     end

--- a/spec/recipes/cron_spec.rb
+++ b/spec/recipes/cron_spec.rb
@@ -26,27 +26,37 @@ describe 'magento-ng::cron' do
     it "creates project cron.d file" do
       expect(chef_run).to create_cron_d('magento-project').with(
         command: 'sh /var/www/project/current/public/cron.sh',
+        minute: '*',
         user: 'www-data'
       )
     end
   end
 
-   context 'with aow schedule and watchdog' do
+   context 'with aoe schedule and watchdog' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
         node.set['nginx']['sites'] = {}
         node.set['apache']['sites']['project']['type'] = 'magento'
         node.set['apache']['sites']['project']['docroot'] = '/var/www/project/current/public'
-        node.set['apache']['sites']['project']['aoe_scheduler'] = true
-        node.set['apache']['sites']['project']['watchdog'] = true
+        node.set['apache']['sites']['project']['magento']['cron_type'] = 'aoe_scheduler'
       end.converge(described_recipe)
     end
 
    it "creates project cron.d file using aoe schdule and watchdog" do
-      expect(chef_run).to create_cron_d('magento-project').with(
-        command: 'sh /var/www/project/current/public/schedule_cron.sh --mode always',
-        command: 'sh /var/www/project/current/public/schedule_cron.sh --mode default',
+      expect(chef_run).not_to create_cron_d('magento-project')
+      expect(chef_run).to create_cron_d('magento-project-aoe-always').with(
+        command: 'sh /var/www/project/current/public/scheduler_cron.sh --mode always',
+        minute: '*',
+        user: 'www-data'
+      )
+      expect(chef_run).to create_cron_d('magento-project-aoe-default').with(
+        command: 'sh /var/www/project/current/public/scheduler_cron.sh --mode default',
+        minute: '*',
+        user: 'www-data'
+      )
+      expect(chef_run).to create_cron_d('magento-project-aoe-watchdog').with(
         command: 'cd /var/www/project/current/public/shell && /usr/bin/php scheduler.php --action watchdog',
+        minute: '*/10',
         user: 'www-data'
       )
     end
@@ -58,15 +68,21 @@ describe 'magento-ng::cron' do
         node.set['nginx']['sites'] = {}
         node.set['apache']['sites']['project']['type'] = 'magento'
         node.set['apache']['sites']['project']['docroot'] = '/var/www/project/current/public'
-        node.set['apache']['sites']['project']['aoe_scheduler'] = true
-        node.set['apache']['sites']['project']['watchdog'] = false
+        node.set['apache']['sites']['project']['magento']['cron_type'] = 'aoe_scheduler'
+        node.set['apache']['sites']['project']['magento']['aoe_scheduler']['watchdog']['enabled'] = false
       end.converge(described_recipe)
     end
 
    it "creates project cron.d file using aoe schduler and no watchdog" do
-      expect(chef_run).to create_cron_d('magento-project').with(
-        command: 'sh /var/www/project/current/public/schedule_cron.sh --mode always',
-        command: 'sh /var/www/project/current/public/schedule_cron.sh --mode default',
+      expect(chef_run).not_to create_cron_d('magento-project')
+      expect(chef_run).to create_cron_d('magento-project-aoe-always').with(
+        command: 'sh /var/www/project/current/public/scheduler_cron.sh --mode always',
+        minute: '*',
+        user: 'www-data'
+      )
+      expect(chef_run).to create_cron_d('magento-project-aoe-default').with(
+        command: 'sh /var/www/project/current/public/scheduler_cron.sh --mode default',
+        minute: '*',
         user: 'www-data'
       )
     end

--- a/spec/recipes/cron_spec.rb
+++ b/spec/recipes/cron_spec.rb
@@ -31,6 +31,25 @@ describe 'magento-ng::cron' do
     end
   end
 
+   context 'with schedule cron ' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['nginx']['sites'] = {}
+        node.set['apache']['sites']['project']['type'] = 'magento'
+        node.set['apache']['sites']['project']['docroot'] = '/var/www/project/current/public'
+        node.set['apache']['sites']['project']['aoe_scheduler'] = true
+      end.converge(described_recipe)
+    end
+
+   it "creates project cron.d file using schdule cron sh" do
+      expect(chef_run).to create_cron_d('magento-project').with(
+        command: 'sh /var/www/project/current/public/schedule_cron.sh --mode always',
+        command: 'sh /var/www/project/current/public/schedule_cron.sh --mode default',
+        user: 'www-data'
+      )
+    end
+  end
+
   context 'with default attributes and one nginx project site' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|

--- a/spec/recipes/cron_spec.rb
+++ b/spec/recipes/cron_spec.rb
@@ -31,17 +31,39 @@ describe 'magento-ng::cron' do
     end
   end
 
-   context 'with schedule cron ' do
+   context 'with aow schedule and watchdog' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
         node.set['nginx']['sites'] = {}
         node.set['apache']['sites']['project']['type'] = 'magento'
         node.set['apache']['sites']['project']['docroot'] = '/var/www/project/current/public'
         node.set['apache']['sites']['project']['aoe_scheduler'] = true
+        node.set['apache']['sites']['project']['watchdog'] = true
       end.converge(described_recipe)
     end
 
-   it "creates project cron.d file using schdule cron sh" do
+   it "creates project cron.d file using aoe schdule and watchdog" do
+      expect(chef_run).to create_cron_d('magento-project').with(
+        command: 'sh /var/www/project/current/public/schedule_cron.sh --mode always',
+        command: 'sh /var/www/project/current/public/schedule_cron.sh --mode default',
+        command: 'cd /var/www/project/current/public/shell && /usr/bin/php scheduler.php --action watchdog',
+        user: 'www-data'
+      )
+    end
+  end
+
+   context 'with aoe schedule but no watchdog ' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['nginx']['sites'] = {}
+        node.set['apache']['sites']['project']['type'] = 'magento'
+        node.set['apache']['sites']['project']['docroot'] = '/var/www/project/current/public'
+        node.set['apache']['sites']['project']['aoe_scheduler'] = true
+        node.set['apache']['sites']['project']['watchdog'] = false
+      end.converge(described_recipe)
+    end
+
+   it "creates project cron.d file using aoe schduler and no watchdog" do
       expect(chef_run).to create_cron_d('magento-project').with(
         command: 'sh /var/www/project/current/public/schedule_cron.sh --mode always',
         command: 'sh /var/www/project/current/public/schedule_cron.sh --mode default',

--- a/test/integration/cron-aoe/serverspec/cron_spec.rb
+++ b/test/integration/cron-aoe/serverspec/cron_spec.rb
@@ -1,0 +1,18 @@
+require 'serverspec'
+set :backend, :exec
+set :path, '/sbin:/usr/local/sbin:$PATH'
+
+describe "AOE Cron" do
+  describe file("/etc/cron.d/magento-site1-aoe-always") do
+    it { should be_file }
+    its(:content) { should match /.*\* \* \* \* \* apache sh \/docroot\/scheduler_cron.sh --mode always.*/ }
+  end
+  describe file("/etc/cron.d/magento-site1-aoe-default") do
+    it { should be_file }
+    its(:content) { should match /.*\* \* \* \* \* apache sh \/docroot\/scheduler_cron.sh --mode default.*/ }
+  end
+  describe file("/etc/cron.d/magento-site1-aoe-watchdog") do
+    it { should be_file }
+    its(:content) { should match /.*\*\/10 \* \* \* \* apache cd \/docroot\/shell && \/usr\/bin\/php scheduler.php --action watchdog.*/ }
+  end
+end


### PR DESCRIPTION
- [x] Add aoe scheduler flag to use scheduler_cron.sh file
- [x] Add watchdog flag to add additional command for watchdog

`.../scheduler_cron.sh --mode always`
`.../scheduler_cron.sh --mode default`
`...cd /vagrant/public/shell && /usr/bin/php scheduler.php --action watchdog`