### PR TITLE
Fix nginx cookbook version selection.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,9 @@
 source 'https://supermarket.chef.io'
 
 metadata
+
+group :integration do
+  cookbook 'aws', '< 2.9.0'
+  cookbook 'ohai', '~> 1.1'
+  cookbook 'yum', '>= 3.0'
+end


### PR DESCRIPTION
Issue: `berks` chose nginx 1.8.0 which fails due to yum 2.x being used.
This was caused by aws cookbook releasing v2.9.0 which increased the
ohai version to be 2.1.0+.
The database cookbook requires any version of the aws cookbook.
The nginx cookbook requires '~> 1.1' of ohai so berkshelf picks the
best version that uses any version of ohai, 1.8.0.