### PR TITLE
Stop using capistrano for the test-kitchen "stack" suite.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -72,3 +72,4 @@ suites:
             magento:
               app:
                 crypt_key: "foo"
+            capistrano: false


### PR DESCRIPTION
Fixes an issue where the logrotate serverspec was not passing.
This was due to the capistrano path "/shared/public/var/log/*.log"
being used in the logrotate configuration, yet serverspec was testing
for "/docroot/public/var/log/*.log".

The alternative solution is to update the tests...