### PR TITLE
Add support for kitchen-docker driver

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -1,0 +1,37 @@
+---
+driver:
+  name: docker
+
+driver_config:
+  require_chef_omnibus: false
+  use_sudo: false
+  privileged: true
+  private_key: .kitchen/docker_id_rsa
+  public_key: .kitchen/docker_id_rsa.pub
+
+platforms:
+<% %w(5.11 6.6 7.0).each do |centos_version| %>
+  - name: centos-<%= centos_version %>
+    driver_config:
+      provision_command:
+        - yum makecache && yum -y install autoconf bison flex gcc gcc-c++ kernel-devel make m4 curl tar
+        - curl -L https://www.opscode.com/chef/install.sh | bash -s -- -v 11.18.12 -d /tmp/vagrant-cache/vagrant_omnibus/
+        - env GEM_HOME=/tmp/verifier/gems GEM_PATH=/tmp/verifier/gems GEM_CACHE=/tmp/verifier/gems/cache /opt/chef/embedded/bin/gem install --no-ri --no-rdoc net-ssh -v '2.9.2'
+        - env GEM_HOME=/tmp/verifier/gems GEM_PATH=/tmp/verifier/gems GEM_CACHE=/tmp/verifier/gems/cache /opt/chef/embedded/bin/gem install --no-ri --no-rdoc thor busser busser-serverspec serverspec bundler cucumber rspec-expectations
+        - chown -R kitchen:kitchen /tmp/verifier
+      volume:
+      <% if File.exist?("~/.vagrant.d/cache/opscode-centos-#{centos_version}") %>
+        - ~/.vagrant.d/cache/opscode-centos-<%= centos_version %>/chef:/var/chef/cache
+        - ~/.vagrant.d/cache/opscode-centos-<%= centos_version %>/vagrant_omnibus:/tmp/vagrant-cache/vagrant_omnibus/
+        - ~/.vagrant.d/cache/opscode-centos-<%= centos_version %>/yum:/var/cache/yum
+      <% end %>
+    <% if centos_version.to_f >= 7.0 %>
+      run_command: /usr/lib/systemd/systemd
+    <% end %>
+    run_list:
+      - recipe[yum]
+    attributes:
+      yum:
+        main:
+          keepcache: true
+<% end %>

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,9 +9,15 @@ provisioner:
   chef_omnibus_install_options: -d /tmp/vagrant-cache/vagrant_omnibus
 
 platforms:
-  - name: centos-5.11
-  - name: centos-6.6
-  - name: centos-7.0
+<% %w(5.11 6.6 7.0).each do |version| %>
+  - name: centos-<%= version %>
+    run_list:
+      - recipe[yum]
+    attributes:
+      yum:
+        main:
+          keepcache: true
+<% end %>
 
 suites:
   - name: cron

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'berkshelf', '~> 4.0.1'
 group :integration do
   gem 'kitchen-vagrant', '~> 0.19.0'
   gem 'test-kitchen', '~> 1.4.2'
+  gem 'kitchen-docker', '~> 2.3.0'
 end
 
 group :test do

--- a/README.md
+++ b/README.md
@@ -268,13 +268,13 @@ Testing
 -------
 
 We use the following testing tools on this project, which can be installed by running `bundle install`.
-These will all run when you perform `bundle exec rake`, however if you wish to know how to run them individually,
+These will all run when you perform `bundle exec rake test`, however if you wish to know how to run them individually,
 they are listed below.
 
-  RSpec/ChefSpec for spec style TDD: `bundle exec rspec`
-  Test Kitchen for TDD and testing out individual recipes on a test Virtual Machine: `bundle exec kitchen test`
-  Foodcritic to catch Chef specific style/correctness errors: `bundle exec foodcritic . -f any -C`
-  Rubocop to catch Ruby style "offenses": `bundle exec rubocop`
+    RSpec/ChefSpec for spec style TDD: `bundle exec rspec`
+    Test Kitchen for TDD and testing out individual recipes on a test Virtual Machine: `bundle exec kitchen test`
+    Foodcritic to catch Chef specific style/correctness errors: `bundle exec foodcritic . -f any -C`
+    Rubocop to catch Ruby style "offenses": `bundle exec rubocop`
 
 Test-Kitchen via vagrant can be quite slow at starting VMs. To help with this, there is the opportunity to use
 test-kitchen's docker plugin and save up to a minute per VM.
@@ -284,11 +284,12 @@ To use kitchen-docker, we need to do a bit of extra setup:
 2. Let test-kitchen know about the `.kitchen.docker.yml` file with the following in your `.bashrc` or other shell
    configuration: `export KITCHEN_LOCAL_YAML=.kitchen.docker.yml`
 3. To re-use the same public/private key each time you run the test suite, you should generate a passwordless SSH key:
-
-  ssh-keygen -t rsa -b 2048 -f .kitchen/docker_id_rsa
-  # and until https://github.com/portertech/kitchen-docker/commit/22cd89828659d9c5f3dd3b9e9cdaaa965a5dd3d4 is released
-  cat .kitchen/docker_id_rsa.pub | tr -d '\n' | tee .kitchen/docker_id_rsa.pub
-  chmod 400 .kitchen/docker_id_rsa*
+```
+ssh-keygen -t rsa -b 2048 -f .kitchen/docker_id_rsa
+# and until https://github.com/portertech/kitchen-docker/commit/22cd89828659d9c5f3dd3b9e9cdaaa965a5dd3d4 is released
+cat .kitchen/docker_id_rsa.pub | tr -d '\n' | tee .kitchen/docker_id_rsa.pub
+chmod 400 .kitchen/docker_id_rsa*
+```
 
 Supermarket share
 -----------------

--- a/README.md
+++ b/README.md
@@ -264,6 +264,32 @@ Contributing
 5. Run the tests, ensuring they all pass
 6. Submit a Pull Request using Github
 
+Testing
+-------
+
+We use the following testing tools on this project, which can be installed by running `bundle install`.
+These will all run when you perform `bundle exec rake`, however if you wish to know how to run them individually,
+they are listed below.
+
+  RSpec/ChefSpec for spec style TDD: `bundle exec rspec`
+  Test Kitchen for TDD and testing out individual recipes on a test Virtual Machine: `bundle exec kitchen test`
+  Foodcritic to catch Chef specific style/correctness errors: `bundle exec foodcritic . -f any -C`
+  Rubocop to catch Ruby style "offenses": `bundle exec rubocop`
+
+Test-Kitchen via vagrant can be quite slow at starting VMs. To help with this, there is the opportunity to use
+test-kitchen's docker plugin and save up to a minute per VM.
+To use kitchen-docker, we need to do a bit of extra setup:
+
+1. Have a working docker installation
+2. Let test-kitchen know about the `.kitchen.docker.yml` file with the following in your `.bashrc` or other shell
+   configuration: `export KITCHEN_LOCAL_YAML=.kitchen.docker.yml`
+3. To re-use the same public/private key each time you run the test suite, you should generate a passwordless SSH key:
+
+  ssh-keygen -t rsa -b 2048 -f .kitchen/docker_id_rsa
+  # and until https://github.com/portertech/kitchen-docker/commit/22cd89828659d9c5f3dd3b9e9cdaaa965a5dd3d4 is released
+  cat .kitchen/docker_id_rsa.pub | tr -d '\n' | tee .kitchen/docker_id_rsa.pub
+  chmod 400 .kitchen/docker_id_rsa*
+
 Supermarket share
 -----------------
 


### PR DESCRIPTION
Speeds up test-kitchen by about a minute for each VM that virtualbox would have created, so 9 minutes!!
It also pre-installs the serverspec gems into the container.

Requires a working docker setup. For OSX users, dinghy may be an appropriate choice.