### PR TITLE
Fixed an incorrectly named block parameter in the etc-local recipe

### DIFF
--- a/recipes/etc-local.rb
+++ b/recipes/etc-local.rb
@@ -18,7 +18,7 @@
 #
 
 %w( apache nginx ).each do |type|
-  node[type]['sites'].each_pair do |_name, site|
+  node[type]['sites'].each_pair do |name, site|
     next unless site['type'] == 'magento'
 
     magento = ConfigDrivenHelper::Util.immutablemash_to_hash(node['magento'])


### PR DESCRIPTION
Fixed an incorrectly named block parameter in the `etc-local` recipe, this is currently causing issues with the Magento hem seed on the CentOS7 PHP 5.6 stack.