### PR TITLE
Updated Chef and Ruby dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,5 +14,5 @@ Style/HashSyntax:
     - spec/**/*
     - Rakefile
 
-Style/SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.0
   - 2.1
   - 2.2
+before_install:
+  - gem update --system
 script:
   - bundle exec rake travis

--- a/Gemfile
+++ b/Gemfile
@@ -1,17 +1,18 @@
 source 'https://rubygems.org'
 
-gem 'rake', '~> 10.1'
-gem 'berkshelf', '~> 4.0.1'
+gem 'rake', '~> 11.1'
+gem 'berkshelf', '~> 4.3'
+gem 'chef', '~> 12.5'
 
 group :integration do
-  gem 'kitchen-vagrant', '~> 0.19.0'
-  gem 'test-kitchen', '~> 1.4.2'
+  gem 'kitchen-vagrant', '~> 0.20'
+  gem 'test-kitchen', '~> 1.7'
 end
 
 group :test do
-  gem 'chefspec', '~> 4.4.0'
-  gem 'foodcritic', '~> 4.0'
-  gem 'rubocop', '~> 0.34.2'
+  gem 'chefspec', '~> 4.6'
+  gem 'foodcritic', '~> 6.2'
+  gem 'rubocop', '~> 0.39'
 end
 
 group :deployment do

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,8 @@ license          'All rights reserved'
 description      'Installs/Configures magento-ng'
 long_description 'Installs/Configures magento-ng'
 version          '0.4.1'
+source_url       'https://github.com/inviqa/chef-magento-ng'
+issues_url       'https://github.com/inviqa/chef-magento-ng/issues'
 
 depends 'config-driven-helper', '~> 1.5'
 depends 'cron', '~> 1.4'

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -36,7 +36,7 @@
         ConfigDrivenHelper::Util.immutablemash_to_hash(site['magento']))
     end
 
-    cron_user = if (!site['cron'].nil?) && site['cron']['user']
+    cron_user = if !site['cron'].nil? && site['cron']['user']
                   site['cron']['user']
                 else
                   case type

--- a/recipes/etc-local.rb
+++ b/recipes/etc-local.rb
@@ -35,7 +35,7 @@
       ).select { |attr| magento['app'][attr].nil? }.map { |attr| "node['#{type}']['sites']['#{name}']['magento']['app']['#{attr}']" }
 
       unless missing_attrs.empty?
-        fail "You must set #{missing_attrs.join(', ')} in chef-solo mode."
+        raise "You must set #{missing_attrs.join(', ')} in chef-solo mode."
       end
     else
       # generate all passwords
@@ -43,11 +43,11 @@
       node.save
     end
 
-    if site['capistrano']
-      config_path = "#{site['capistrano']['deploy_to']}/shared/#{magento['app']['base_path']}"
-    else
-      config_path = site['docroot']
-    end
+    config_path = if site['capistrano']
+                    "#{site['capistrano']['deploy_to']}/shared/#{magento['app']['base_path']}"
+                  else
+                    site['docroot']
+                  end
 
     directory "#{config_path}/app/etc" do
       recursive true

--- a/recipes/logrotate.rb
+++ b/recipes/logrotate.rb
@@ -29,11 +29,11 @@
         ConfigDrivenHelper::Util.immutablemash_to_hash(site['magento']))
     end
 
-    if site['capistrano']
-      config_path = "#{site['capistrano']['deploy_to']}/shared/#{magento['app']['base_path']}"
-    else
-      config_path = site['docroot']
-    end
+    config_path = if site['capistrano']
+                    "#{site['capistrano']['deploy_to']}/shared/#{magento['app']['base_path']}"
+                  else
+                    site['docroot']
+                  end
 
     logrotate_app "magento-#{name}" do
       path "#{config_path}/var/log/*.log"


### PR DESCRIPTION
Chef and Ruby dependencies have been updated to the latest versions and new RuboCop violations have been fixed. Support has been dropped for Ruby versions <= 2.0 and the Chef version requirement is now 12.5+ since the IP tables cookbook dependency uses the `property` method, which was introduced in Chef 12.5.