### PR TITLE
Remove ignored logrotate missingok option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
+## 0.5.1 (05 August 2016)
+
+BUG FIXES:
+
+  * #34 Remove ignored logrotate missingok option 
+
 ## 0.5.0 (06 May 2016)
+
+CHANGES:
 
   * #31 Update config-driven-helper to allow for version >= 1.5, < 3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.1 (05 August 2016)
+## 0.5.1 (14 September 2016)
 
 BUG FIXES:
 

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ namespace :style do
 end
 
 desc 'Run all style checks'
-task :style => %w( style:chef style:ruby )
+task :style => %w(style:chef style:ruby)
 
 # Rspec and ChefSpec
 desc 'Run ChefSpec examples'
@@ -39,6 +39,6 @@ namespace :integration do
   end
 end
 
-task :travis => %w( style spec )
+task :travis => %w(style spec)
 
-task :test => %w( style spec integration:vagrant )
+task :test => %w(style spec integration:vagrant)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,7 +53,6 @@ default['magento']['aoe_scheduler']['default']['minute'] = '*'
 default['magento']['aoe_scheduler']['watchdog']['mode'] = 'watchdog'
 default['magento']['aoe_scheduler']['watchdog']['minute'] = '*/10'
 
-default['magento']['logrotate']['missingok'] = true
 default['magento']['logrotate']['frequency'] = 'weekly'
 default['magento']['logrotate']['rotate'] = 4
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -56,11 +56,11 @@ default['magento']['aoe_scheduler']['watchdog']['minute'] = '*/10'
 default['magento']['logrotate']['frequency'] = 'weekly'
 default['magento']['logrotate']['rotate'] = 4
 
-%w( apache nginx ).each do |type|
+%w(apache nginx).each do |type|
   default[type]['shared_config']['magento'] = {
     'clustered' => false,
     'type' => 'magento',
-    'protocols' => %w( http https),
+    'protocols' => %w(http https),
     'locations' => {
       '/app' => 'restricted',
       '/dev' => 'restricted',

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'athompson@inviqa.com'
 license          'All rights reserved'
 description      'Installs/Configures magento-ng'
 long_description 'Installs/Configures magento-ng'
-version          '0.5.0'
+version          '0.5.1'
 source_url       'https://github.com/inviqa/chef-magento-ng'
 issues_url       'https://github.com/inviqa/chef-magento-ng/issues'
 

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-%w( apache nginx ).each do |type|
+%w(apache nginx).each do |type|
   node[type]['sites'].each do |name, site|
     next unless site['type'] == 'magento'
 
@@ -33,7 +33,8 @@
     if site['magento']
       magento = ::Chef::Mixin::DeepMerge.hash_only_merge(
         magento,
-        ConfigDrivenHelper::Util.immutablemash_to_hash(site['magento']))
+        ConfigDrivenHelper::Util.immutablemash_to_hash(site['magento'])
+      )
     end
 
     cron_user = if !site['cron'].nil? && site['cron']['user']

--- a/recipes/etc-local.rb
+++ b/recipes/etc-local.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-%w( apache nginx ).each do |type|
+%w(apache nginx).each do |type|
   node[type]['sites'].each_pair do |name, site|
     next unless site['type'] == 'magento'
 
@@ -26,7 +26,8 @@
     if site['magento']
       magento = ::Chef::Mixin::DeepMerge.hash_only_merge(
         magento,
-        ConfigDrivenHelper::Util.immutablemash_to_hash(site['magento']))
+        ConfigDrivenHelper::Util.immutablemash_to_hash(site['magento'])
+      )
     end
 
     if Chef::Config[:solo]
@@ -59,7 +60,7 @@
 
     template "#{config_path}/app/etc/local.xml" do
       source 'magento-local.xml.erb'
-      mode 0644
+      mode 0o0644
       variables(
         :magento => magento
       )

--- a/recipes/logrotate.rb
+++ b/recipes/logrotate.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-%w( apache nginx ).each do |type|
+%w(apache nginx).each do |type|
   node[type]['sites'].each_pair do |name, site|
     next unless site['type'] == 'magento'
 
@@ -26,7 +26,8 @@
     if site['magento']
       magento = ::Chef::Mixin::DeepMerge.hash_only_merge(
         magento,
-        ConfigDrivenHelper::Util.immutablemash_to_hash(site['magento']))
+        ConfigDrivenHelper::Util.immutablemash_to_hash(site['magento'])
+      )
     end
 
     config_path = if site['capistrano']

--- a/spec/recipes/logrotate_spec.rb
+++ b/spec/recipes/logrotate_spec.rb
@@ -63,7 +63,7 @@ describe 'magento-ng::logrotate' do
       ChefSpec::SoloRunner.new do |node|
         node.set['nginx']['sites']['project']['type'] = 'magento'
         node.set['nginx']['sites']['project']['docroot'] = '/var/www/project/current/public'
-        node.set['nginx']['sites']['project']['logrotate']['missingok'] = false
+        node.set['nginx']['sites']['project']['capistrano']['deploy_to'] = '/var/www/project'
         node.set['nginx']['sites']['project']['logrotate']['delaycompress'] = true
       end.converge(described_recipe)
     end


### PR DESCRIPTION
This was silently ignored as only was ever accepted as an `['options'] = ['missingok']`.

logrotate v2.0 changed the definition to a resource, which made all of its arguments stricter.

Since the default options include missingok, this option needn't be specified