### PR TITLE
Fix double escape for RSS location under NGINX.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.4 (1 November 2017)
+
+BUG FIXES:
+
+  * #39 Fix double-escaping the regular expression to deny access to RSS feeds.
+  * #40 Rubocop style issues
+
 ## 1.0.3 (21 June 2017)
 
 BUG FIXES:
@@ -26,7 +33,7 @@ CHANGES:
 
 BUG FIXES:
 
-  * #34 Remove ignored logrotate missingok option 
+  * #34 Remove ignored logrotate missingok option
 
 ## 0.5.0 (06 May 2016)
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -95,7 +95,10 @@ default['magento']['logrotate']['rotate'] = 4
       '/media/downloadable' => 'restricted',
       '/pkginfo' => 'restricted',
       '/report/config.xml' => 'restricted',
-      '^(/index\.php)?/?(.+/)?rss/(catalog/(notifystock|review)|order/new)(/|$)' => 'restricted',
+      '^(/index\.php)?/?(.+/)?rss/(catalog/(notifystock|review)|order/new)(/|$)' => {
+        'type' => 'regex',
+        'mode' => 'restricted'
+      },
       '/shell' => 'restricted',
       '/skin' => 'static',
       '/var' => 'restricted',

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'athompson@inviqa.com'
 license          'All rights reserved'
 description      'Installs/Configures magento-ng'
 long_description 'Installs/Configures magento-ng'
-version          '1.0.3'
+version          '1.0.4'
 source_url       'https://github.com/inviqa/chef-magento-ng'
 issues_url       'https://github.com/inviqa/chef-magento-ng/issues'
 


### PR DESCRIPTION
The RSS location was being double-escaped due to `type` not being set to 'regex' and this code not triggering: https://github.com/inviqa/chef-config-driven-helper/blob/master/templates/default/nginx_site.conf.erb#L49-L53